### PR TITLE
Raise result limit & make it configurable

### DIFF
--- a/lib/dradis/plugins/mediawiki/engine.rb
+++ b/lib/dradis/plugins/mediawiki/engine.rb
@@ -12,6 +12,7 @@ module Dradis::Plugins::Mediawiki
       settings.default_path      = 'mediawiki/api.php'
       settings.default_port      = 443
       settings.default_scheme    = 'http(s)'
+      settings.default_limit     = 'max'
     end
   end
 end

--- a/lib/dradis/plugins/mediawiki/filters.rb
+++ b/lib/dradis/plugins/mediawiki/filters.rb
@@ -7,18 +7,19 @@ module Dradis::Plugins::Mediawiki::Filters
       path   = Dradis::Plugins::Mediawiki::Engine.settings.path
       port   = Dradis::Plugins::Mediawiki::Engine.settings.port
       scheme = Dradis::Plugins::Mediawiki::Engine.settings.scheme
+      limit = Dradis::Plugins::Mediawiki::Engine.settings.limit
 
       port   = (scheme == 'https' ? 443 : 80) if port.blank?
 
       begin
         # Parameters required by MediaWiki API
-        # http://localhost/mediawiki-1.21.1/api.php?action=query&prop=revisions&generator=search&gsrwhat=text&gsrsearch=Directory&rvprop=content&format=xml
+        # http://localhost/mediawiki-1.21.1/api.php?action=query&prop=revisions&generator=search&gsrwhat=text&gsrlimit=max&gsrsearch=Directory&rvprop=content&format=xml
         filter_params = {
              action: 'query',
                prop: 'revisions',
           generator: 'search',
             gsrwhat: 'text',
-           gsrlimit: 'max',
+           gsrlimit: CGI::escape(limit),
           gsrsearch: CGI::escape(params[:query]), # user query
              rvprop: 'content',
              format: 'xml'

--- a/lib/dradis/plugins/mediawiki/filters.rb
+++ b/lib/dradis/plugins/mediawiki/filters.rb
@@ -18,7 +18,7 @@ module Dradis::Plugins::Mediawiki::Filters
                prop: 'revisions',
           generator: 'search',
             gsrwhat: 'text',
-           gsrlimit: 50,
+           gsrlimit: 'max',
           gsrsearch: CGI::escape(params[:query]), # user query
              rvprop: 'content',
              format: 'xml'

--- a/lib/dradis/plugins/mediawiki/filters.rb
+++ b/lib/dradis/plugins/mediawiki/filters.rb
@@ -18,6 +18,7 @@ module Dradis::Plugins::Mediawiki::Filters
                prop: 'revisions',
           generator: 'search',
             gsrwhat: 'text',
+           gsrlimit: 50,
           gsrsearch: CGI::escape(params[:query]), # user query
              rvprop: 'content',
              format: 'xml'


### PR DESCRIPTION
### Summary

This PR changes the search to return as many results as possible instead of the default 10. It also exposes this as a configurable setting.

### Other Information

The MediaWiki default is to return 10 results per search, which means many results may be omitted if searching for a common keyword.

We've used a patch that raises the limit to 50 (arbitrarily), but looking at the [API docs](https://www.mediawiki.org/wiki/API:Search) I found that you can pass `max` as the limit to return all results (500 seems to be the actual maximum).

We've used these changes for a while now, and have not had any issues. The results page accommodates even long lists of results very well.

I didn't add any tests as there weren't any existing ones for the search params, but I'm open to suggestions. :)

### Copyright assignment

I agree to the [Contributor's Agreement](https://github.com/dradis/dradis-ce/wiki/Contributor%27s-agreement) and assign all rights, including copyright, to these Contributions to Security Roots.
