### PR TITLE
Avoid double-encoding query

### DIFF
--- a/lib/dradis/plugins/mediawiki/filters.rb
+++ b/lib/dradis/plugins/mediawiki/filters.rb
@@ -18,7 +18,7 @@ module Dradis::Plugins::Mediawiki::Filters
                prop: 'revisions',
           generator: 'search',
             gsrwhat: 'text',
-          gsrsearch: CGI::escape(params[:query]), # user query
+          gsrsearch: params[:query], # user query
              rvprop: 'content',
              format: 'xml'
         }


### PR DESCRIPTION

### Summary

Queries that use non-URL-safe characters currently get double-encoded, causing MediaWiki not to return any matching results.

### Other Information

`Hash#to_query` already URL-encodes the values. Calling `CGI::escape` on top of that causes reserved characters and non-ASCII characters to be double-encoded.

E.g.

```ruby
> {foo: "ê!"}.to_query
=> "foo=%C3%AA%21"

> {foo: CGI::escape("ê!")}.to_query
=> "foo=%25C3%25AA%2521"
```

I suspected this was the case in https://github.com/dradis/dradis-mediawiki/pull/17#discussion_r361127489, but I didn't investigate it properly until now. 

### Copyright assignment

I agree to the [Contributor's Agreement](https://github.com/dradis/dradis-ce/wiki/Contributor%27s-agreement) and assign all rights, including copyright, to these Contributions to Security Roots.
