### PR TITLE
Update dradis-mediawiki.gemspec

### DIFF
--- a/dradis-mediawiki.gemspec
+++ b/dradis-mediawiki.gemspec
@@ -24,7 +24,7 @@ Gem::Specification.new do |spec|
   # versions of Rails (a sure recipe for disaster, I'm sure), which is needed
   # until we bump Dradis Pro to 4.1.
   # s.add_dependency 'rails', '~> 4.1.1'
-  spec.add_dependency 'dradis-plugins', '~> 4.0'
+  spec.add_dependency 'dradis-plugins', '~> 4.1'
 
   spec.add_development_dependency 'bundler', '~> 1.6'
   spec.add_development_dependency 'rake', '~> 10.0'


### PR DESCRIPTION
### Summary

Fixes the reference to dradis-plugins v4.0 for the v4.1 version.


### Copyright assignment

I assign all rights, including copyright, to any future Dradis work by myself to Security Roots.
