### PR TITLE
Update Dradis links

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+v4.12.0 (XXXX 2024)
+  - Update Dradis links in README
+
 v4.11.0 (January 2024)
   - No changes
 

--- a/README.md
+++ b/README.md
@@ -9,8 +9,7 @@ The idea is to be able to use a MediaWiki as a library of re-usable report entri
 
 The add-on performs a text search against the WikiMedia API. See http://www.mediawiki.org/wiki/API for further reference.
 
-The add-on requires [Dradis CE](https://dradisframework.org/) > 3.0, or [Dradis Pro](https://dradisframework.com/pro/).
-
+The add-on requires [Dradis CE](https://dradis.com/ce/) > 3.0, or [Dradis Pro](https://dradis.com/).
 
 ## More information
 


### PR DESCRIPTION
### Summary

Update README so that Dradis CE and Dradis links are now using https://dradis.com/ce/ and https://dradis.com/ respectively.

### Copyright assignment

> I assign all rights, including copyright, to any future Dradis
> work by myself to Security Roots.

### Check List

- [x] Added a CHANGELOG entry
- [ ] Added specs
